### PR TITLE
feat: Added contract queue messages for site creation and updates

### DIFF
--- a/src/routes/sites.ts
+++ b/src/routes/sites.ts
@@ -199,11 +199,13 @@ app.post("/", async (c) => {
       return c.json({ message: "Subdomain already exists" }, 400);
     }
 
-    const contractRes = await createContract(c);
-
-    if (!contractRes) {
-      throw Error("Problem creating contract");
-    }
+    await c.env.CONTRACT_QUEUE.send({
+      type: 'create_contract',
+      cid: cid,
+      domain: subdomain.toLowerCase(),
+      userId: user ? user.id : organizationData?.orgOwner,
+      orgId: orgId
+    });
 
     const html: any = await getSiteData(c, cid);
 
@@ -217,16 +219,12 @@ app.post("/", async (c) => {
       userIdToUser!,
       orgId,
       subdomain.toLowerCase(),
-      cid,
-      contractRes.args.cloneAddress
+      cid
     );
     //	Next we need to map the user's domain to the new CID using Cloudflare KV
     await c.env.ORBITER_SITES.put(subdomain.toLowerCase(), cid);
-    await c.env.SITE_CONTRACT.put(subdomain.toLowerCase(), contractRes.args.cloneAddress)
     await c.env.SITE_TO_ORG.put(subdomain.toLowerCase(), orgId);
     //	@TODO If the user has a custom domain, we must map both the custom domain and default domain to the CID
-    console.log("Writing...");
-    await writeCID(c, cid, contractRes.args.cloneAddress as `0x${string}`);
     const userDetails = await getUserById(c, userIdToUser!);
 
     await postNewSiteToSlack(c, subdomain, userDetails, cid);
@@ -271,7 +269,16 @@ app.put("/:siteId", async (c) => {
 
     await purgeCache(c, siteInfo.domain);
 
-    await writeCID(c, cid, site_contract as `0x${string}`);
+    if (site_contract) {
+      await c.env.CONTRACT_QUEUE.send({
+        type: 'update_contract',
+        cid: cid,
+        contractAddress: site_contract as `0x${string}`,
+        siteId: siteId,
+        userId: user ? user.id : organizationData?.orgOwner,
+        orgId: organization_id
+      });
+    }
 
     //	Next we need to map the user's domain to the new CID using Cloudflare KV
     const domainPrefix = domain.split(".orbiter.website")[0];

--- a/src/routes/sites.ts
+++ b/src/routes/sites.ts
@@ -220,7 +220,7 @@ app.post("/", async (c) => {
       userIdToUser!,
       orgId,
       subdomain.toLowerCase(),
-      cid
+      cid,
       source
     );
     //	Next we need to map the user's domain to the new CID using Cloudflare KV
@@ -298,8 +298,8 @@ app.put("/:siteId", async (c) => {
       organization_id,
       domainPrefix.toLowerCase(),
       cid,
-      site_contract,
-      source
+      source,
+      site_contract
     );
 
     const userDetails = await getUserById(c, userForDb);

--- a/src/utils/db/sites.ts
+++ b/src/utils/db/sites.ts
@@ -198,18 +198,21 @@ export const createOrUpdateSiteMapping = async (
         c.env.SUPABASE_SERVICE_ROLE_KEY
       );
 
+      const updateData: any = {
+        cid,
+        organization_id: orgId,
+        domain: `${domain}.orbiter.website`,
+        deployed_by: userId,
+      };
+
+      // Only include site_contract if it's provided
+      if (siteContract) {
+        updateData.site_contract = siteContract;
+      }
+
       const { data, error } = await supabase
         .from("sites")
-        .upsert(
-          {
-            cid,
-            organization_id: orgId,
-            domain: `${domain}.orbiter.website`,
-            site_contract: siteContract,
-            deployed_by: userId,
-          },
-          { onConflict: "domain" }
-        )
+        .upsert(updateData, { onConflict: "domain" })
         .select();
 
       if (error) {

--- a/src/utils/db/sites.ts
+++ b/src/utils/db/sites.ts
@@ -187,8 +187,8 @@ export const createOrUpdateSiteMapping = async (
   orgId: string,
   domain: string,
   cid: string,
-  siteContract?: string,
-  source?: string
+  source?: string,
+  siteContract?: string
 ) => {
   try {
     console.log("Updating site mapping!");

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,6 +42,7 @@ export type Bindings = {
   ALCHEMY_URL: string;
   FARCASTER_MNEMONIC: string;
   FARCASTER_FID: string;
+  CONTRACT_QUEUE: Queue;
 };
 
 export type Organization = {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -44,8 +44,8 @@ id = "0a2dc5df8dda441aa9a7b47a09411001"
 binding = "CONTRACT_QUEUE"
 queue = "contract-queue"
 
-[[queues.consumers]]
-queue = "contract-queue"
+# [[queues.consumers]]
+# queue = "contract-queue"
 
 # [[r2_buckets]]
 # binding = "MY_BUCKET"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@ name = "orbiter-backend"
 main = "src/index.ts"
 compatibility_date = "2024-12-23"
 
-compatibility_flags = [ "nodejs_compat" ]
+compatibility_flags = ["nodejs_compat"]
 
 [vars]
 RECAPTCHA_SITE_KEY = "6LcQHqQqAAAAADHN8zgMRAFL8c9DH1sHJ0yu-R-e"
@@ -39,6 +39,13 @@ id = "cd51f5e3da4946d99530e1b825d94b2e"
 [[kv_namespaces]]
 binding = "SITE_CONTRACT"
 id = "0a2dc5df8dda441aa9a7b47a09411001"
+
+[[queues.producers]]
+binding = "CONTRACT_QUEUE"
+queue = "contract-queue"
+
+[[queues.consumers]]
+queue = "contract-queue"
 
 # [[r2_buckets]]
 # binding = "MY_BUCKET"


### PR DESCRIPTION
Updated endpoints `POST /sites` and `PUT /sites/:siteId` to use a new queue worker to handle contract creation and mapping updating. By doing this we can send responses to the user that the site is created without having to wait for those transactions to finalize, as well as handle special retry logic if we need to. 

Please review the queue linked below as well 

[orbiterhost/orbiter-contract-queue](https://github.com/orbiterhost/orbiter-contract-queue)