### PR TITLE
fix: adjusted site info logic to account for api key auth

### DIFF
--- a/src/routes/sites.ts
+++ b/src/routes/sites.ts
@@ -95,7 +95,9 @@ app.get("/:identifier/versions", async (c) => {
           ? await getSiteById(c, lookUpType.value)
           : await getSiteByDomain(c, lookUpType.value);
     } else if (organizationData) {
-      siteInfo = await getSiteById(c, identifier);
+      siteInfo = lookUpType.field === "site_id"
+        ? await getSiteById(c, lookUpType.value)
+        : await getSiteByDomain(c, lookUpType.value);
       if (siteInfo.organization_id !== organizationData?.id) {
         return c.json({ message: "Unauthorized" }, 401);
       }


### PR DESCRIPTION
Fixes an issue where if someone tried to request versions for a site using API key auth the backend would try to query the DB the UUID with the domain provided. 